### PR TITLE
Allow me() and any() to pick up previousElementSibling before parentElement.

### DIFF
--- a/surreal.js
+++ b/surreal.js
@@ -60,7 +60,7 @@ let $ = { // Convenience for internals.
 		if (typeof selector == 'string') {
 			if (selector === 'prev') return $.sugar(start.currentScript.previousElementSibling)
 			if (selector === 'next') return $.sugar(start.currentScript.nextElementSibling)
-			if (isSelector(selector, start, warning)) return $.sugar(start.querySelector(selector)) // String selector.
+			if ($.isSelector(selector, start, warning)) return $.sugar(start.querySelector(selector)) // String selector.
 		}
 		if ($.isNodeList(selector)) return $.me(selector[0]) // If we got a list, just take the first element.
 		if ($.isNode(selector)) return $.sugar(selector) // Valid element.

--- a/surreal.js
+++ b/surreal.js
@@ -55,7 +55,7 @@ let $ = { // Convenience for internals.
 	//		<script>me().style.color = 'red'</script>
 	//	</div>
 	me(selector=null, start=document, warning=true) {
-		if (selector == null) return $.sugar(start.currentScript.parentElement) // Just local me() in <script>
+		if (!selector) return $.sugar(start.currentScript.previousElementSibling || start.currentScript.parentElement) // Just local me() in <script>
 		if (selector instanceof Event) return selector.currentTarget ? $.me(selector.currentTarget) : (console.warn(`Surreal: Event currentTarget is null. Please save your element because async will lose it`), null) // Events try currentTarget
 		if (typeof selector == 'string' && isSelector(selector, start, warning)) return $.sugar(start.querySelector(selector)) // String selector.
 		if ($.isNodeList(selector)) return $.me(selector[0]) // If we got a list, just take the first element.
@@ -67,7 +67,7 @@ let $ = { // Convenience for internals.
 	// Returns an Array of elements (so you can use methods like forEach/filter/map/reduce if you want).
 	// Example: any('button')
 	any(selector, start=document, warning=true) {
-		if (selector == null) return $.sugar([start.currentScript.parentElement]) // Just local me() in <script>
+		if (!selector) return $.sugar([start.currentScript.previousElementSibling || start.currentScript.parentElement]) // Just local me() in <script>
 		if (selector instanceof Event) return selector.currentTarget ? $.any(selector.currentTarget) : (console.warn(`Surreal: Event currentTarget is null. Please save your element because async will lose it`), null) // Events try currentTarget
 		if (typeof selector == 'string' && isSelector(selector, start, true, warning)) return $.sugar(Array.from(start.querySelectorAll(selector))) // String selector.
 		if ($.isNode(selector)) return $.sugar([selector]) // Single element. Convert to Array.

--- a/surreal.js
+++ b/surreal.js
@@ -55,7 +55,7 @@ let $ = { // Convenience for internals.
 	//		<script>me().style.color = 'red'</script>
 	//	</div>
 	me(selector=null, start=document, warning=true) {
-		if (selector == null) return $.sugar(start.currentScript.previousElementSibling) // Just local me() in <script>
+		if (selector == null) return $.sugar(start.currentScript.parentElement) // Just local me() in <script>
 		if (selector instanceof Event) return selector.currentTarget ? $.me(selector.currentTarget) : (console.warn(`Surreal: Event currentTarget is null. Please save your element because async will lose it`), null) // Events try currentTarget
 		if (typeof selector == 'string') {
 			if (selector === 'prev') return $.sugar(start.currentScript.previousElementSibling)
@@ -71,7 +71,7 @@ let $ = { // Convenience for internals.
 	// Returns an Array of elements (so you can use methods like forEach/filter/map/reduce if you want).
 	// Example: any('button')
 	any(selector, start=document, warning=true) {
-		if (selector == null) return $.sugar([start.currentScript.previousElementSibling]) // Just local any() in <script>
+		if (selector == null) return $.sugar([start.currentScript.parentElement]) // Just local any() in <script>
 		if (selector instanceof Event) return selector.currentTarget ? $.any(selector.currentTarget) : (console.warn(`Surreal: Event currentTarget is null. Please save your element because async will lose it`), null) // Events try currentTarget
 		if (typeof selector == 'string') {
 			if (selector === 'prev') return $.sugar([start.currentScript.previousElementSibling])

--- a/surreal.js
+++ b/surreal.js
@@ -55,9 +55,13 @@ let $ = { // Convenience for internals.
 	//		<script>me().style.color = 'red'</script>
 	//	</div>
 	me(selector=null, start=document, warning=true) {
-		if (selector == null) return $.sugar(start.currentScript.previousElementSibling || start.currentScript.parentElement) // Just local me() in <script>
+		if (selector == null) return $.sugar(start.currentScript.previousElementSibling) // Just local me() in <script>
 		if (selector instanceof Event) return selector.currentTarget ? $.me(selector.currentTarget) : (console.warn(`Surreal: Event currentTarget is null. Please save your element because async will lose it`), null) // Events try currentTarget
-		if (typeof selector == 'string' && $.isSelector(selector, start, warning)) return $.sugar(start.querySelector(selector)) // String selector.
+		if (typeof selector == 'string') {
+			if (selector === 'prev') return $.sugar(start.currentScript.previousElementSibling)
+			if (selector === 'next') return $.sugar(start.currentScript.nextElementSibling)
+			if (isSelector(selector, start, warning)) return $.sugar(start.querySelector(selector)) // String selector.
+		}
 		if ($.isNodeList(selector)) return $.me(selector[0]) // If we got a list, just take the first element.
 		if ($.isNode(selector)) return $.sugar(selector) // Valid element.
 		return null // Invalid.
@@ -67,9 +71,13 @@ let $ = { // Convenience for internals.
 	// Returns an Array of elements (so you can use methods like forEach/filter/map/reduce if you want).
 	// Example: any('button')
 	any(selector, start=document, warning=true) {
-		if (selector == null) return $.sugar([start.currentScript.previousElementSibling || start.currentScript.parentElement]) // Just local any() in <script>
+		if (selector == null) return $.sugar([start.currentScript.previousElementSibling]) // Just local any() in <script>
 		if (selector instanceof Event) return selector.currentTarget ? $.any(selector.currentTarget) : (console.warn(`Surreal: Event currentTarget is null. Please save your element because async will lose it`), null) // Events try currentTarget
-		if (typeof selector == 'string' && $.isSelector(selector, start, true, warning)) return $.sugar(Array.from(start.querySelectorAll(selector))) // String selector.
+		if (typeof selector == 'string') {
+			if (selector === 'prev') return $.sugar([start.currentScript.previousElementSibling])
+			if (selector === 'next') return $.sugar([start.currentScript.nextElementSibling])
+			if $.isSelector(selector, start, true, warning)) return $.sugar(Array.from(start.querySelectorAll(selector)))
+		}
 		if ($.isNode(selector)) return $.sugar([selector]) // Single element. Convert to Array.
 		if ($.isNodeList(selector)) return $.sugar(Array.from(selector)) // Valid NodeList or Array.
 		return null // Invalid.

--- a/surreal.js
+++ b/surreal.js
@@ -76,7 +76,7 @@ let $ = { // Convenience for internals.
 		if (typeof selector == 'string') {
 			if (selector === 'prev') return $.sugar([start.currentScript.previousElementSibling])
 			if (selector === 'next') return $.sugar([start.currentScript.nextElementSibling])
-			if $.isSelector(selector, start, true, warning)) return $.sugar(Array.from(start.querySelectorAll(selector)))
+			if ($.isSelector(selector, start, true, warning)) return $.sugar(Array.from(start.querySelectorAll(selector)))
 		}
 		if ($.isNode(selector)) return $.sugar([selector]) // Single element. Convert to Array.
 		if ($.isNodeList(selector)) return $.sugar(Array.from(selector)) // Valid NodeList or Array.

--- a/surreal.js
+++ b/surreal.js
@@ -55,7 +55,7 @@ let $ = { // Convenience for internals.
 	//		<script>me().style.color = 'red'</script>
 	//	</div>
 	me(selector=null, start=document, warning=true) {
-		if (!selector) return $.sugar(start.currentScript.previousElementSibling || start.currentScript.parentElement) // Just local me() in <script>
+		if (selector == null) return $.sugar(start.currentScript.previousElementSibling || start.currentScript.parentElement) // Just local me() in <script>
 		if (selector instanceof Event) return selector.currentTarget ? $.me(selector.currentTarget) : (console.warn(`Surreal: Event currentTarget is null. Please save your element because async will lose it`), null) // Events try currentTarget
 		if (typeof selector == 'string' && $.isSelector(selector, start, warning)) return $.sugar(start.querySelector(selector)) // String selector.
 		if ($.isNodeList(selector)) return $.me(selector[0]) // If we got a list, just take the first element.
@@ -67,7 +67,7 @@ let $ = { // Convenience for internals.
 	// Returns an Array of elements (so you can use methods like forEach/filter/map/reduce if you want).
 	// Example: any('button')
 	any(selector, start=document, warning=true) {
-		if (!selector) return $.sugar([start.currentScript.previousElementSibling || start.currentScript.parentElement]) // Just local any() in <script>
+		if (selector == null) return $.sugar([start.currentScript.previousElementSibling || start.currentScript.parentElement]) // Just local any() in <script>
 		if (selector instanceof Event) return selector.currentTarget ? $.any(selector.currentTarget) : (console.warn(`Surreal: Event currentTarget is null. Please save your element because async will lose it`), null) // Events try currentTarget
 		if (typeof selector == 'string' && $.isSelector(selector, start, true, warning)) return $.sugar(Array.from(start.querySelectorAll(selector))) // String selector.
 		if ($.isNode(selector)) return $.sugar([selector]) // Single element. Convert to Array.

--- a/surreal.js
+++ b/surreal.js
@@ -67,7 +67,7 @@ let $ = { // Convenience for internals.
 	// Returns an Array of elements (so you can use methods like forEach/filter/map/reduce if you want).
 	// Example: any('button')
 	any(selector, start=document, warning=true) {
-		if (!selector) return $.sugar([start.currentScript.previousElementSibling || start.currentScript.parentElement]) // Just local me() in <script>
+		if (!selector) return $.sugar([start.currentScript.previousElementSibling || start.currentScript.parentElement]) // Just local any() in <script>
 		if (selector instanceof Event) return selector.currentTarget ? $.any(selector.currentTarget) : (console.warn(`Surreal: Event currentTarget is null. Please save your element because async will lose it`), null) // Events try currentTarget
 		if (typeof selector == 'string' && $.isSelector(selector, start, true, warning)) return $.sugar(Array.from(start.querySelectorAll(selector))) // String selector.
 		if ($.isNode(selector)) return $.sugar([selector]) // Single element. Convert to Array.


### PR DESCRIPTION
This is a breaking change for people who don't already have their `<script>` directly below the opening parentElement.
It does allow for the ability to pick up void elements like `<input>`