### PR TITLE
fix: callback checks for fadeIn/fadeOut not using typeof

### DIFF
--- a/surreal.js
+++ b/surreal.js
@@ -253,7 +253,7 @@ function pluginEffects(e) {
 				await tick()
 				surreal.styles(e, {transform: 'scale(0.9)', opacity: '0'})
 				await sleep(ms, e)
-				if (fn === 'function') fn(thing) // Run custom callback?
+				if (typeof fn === 'function') fn(thing) // Run custom callback?
 				if (remove) surreal.remove(thing) // Remove element after animation is completed?
 			})()
 		}
@@ -271,7 +271,7 @@ function pluginEffects(e) {
 				await sleep(ms, e)
 				e.style = save // Revert back to original style.
 				surreal.styles(e, {opacity: '1'}) // Ensure we're visible after reverting to original style.
-				if (fn === 'function') fn(thing) // Run custom callback?
+				if (typeof fn === 'function') fn(thing) // Run custom callback?
 			})()
 		}
 	}


### PR DESCRIPTION
Hi,

This library seems pretty cool! I did manage to find a couple of issues while doing some testing, this one was worth opening up a quick PR to fix since provided callbacks aren't running for `fadeIn` and `fadeOut` due to an incorrect check

There's another issue I found when using `me().on('mouseleave', ...)` which I may file an issue later, seems to be related to #3

Let me know if there's anything I need to check here, hopefully we can get this merged!

Thanks